### PR TITLE
 Fix accidental overwrite of global variable dogs in getAllDogs()

### DIFF
--- a/Lectures/lecture_04/code/dogs.js
+++ b/Lectures/lecture_04/code/dogs.js
@@ -17,9 +17,9 @@ module.exports = {
   async getAllDogs() {
     const dogCollection = await dogs();
 
-    const dogs = await dogCollection.find({}).toArray();
+    const doggos = await dogCollection.find({}).toArray();
 
-    return dogs;
+    return doggos;
   },
 
   async addDog(name, breeds) {


### PR DESCRIPTION
In the getAllDogs() function, the global const "dogs = mongoCollections.dogs" is overwritten by line 20, resulting in the "dogs is not defined error"
This changes the variable name to stop the accidental dogs overwrite